### PR TITLE
Fixing cancancan version to <=2.1.4 as latest version is not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ coverage
 .DS_Store
 
 # Gemfile
-.gem
+*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.2
+
+Fixing `cancancan` gem version to `<=2.1.4` as `cancancan-neo4j` gem is not compatible with higher version of  `cancancan`
+
 ## 1.0.1
 
 Fixing `activemodel` gem version to `<5.2.0` as `neo4j` gem is not compatible with `activemodel-5.2.0`

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is the adapter for the [CanCanCan](https://github.com/CanCanCommunity/cancancan) authorization
 library to automatically generate Cypher queries from ability rules. It returns QueryProxy object for resources.
 
-Adds support for neo4j >= 9.0
+Adds support for neo4j >= 9.0 and cancancan <= 2.1.4
 
 ## Ruby Versions Supported
 

--- a/cancancan-neo4j.gemspec
+++ b/cancancan-neo4j.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel', '<5.2.0'
-  spec.add_dependency 'cancancan', '>= 2.0'
+  spec.add_dependency 'cancancan', '<=2.1.4'
   spec.add_dependency 'neo4j', '>= 9.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3'

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.0.2'.freeze
   end
 end


### PR DESCRIPTION
Latest version 2.2.0 of cancancan gem is not supported, so fixing the cancancan version to 2.1.4