### PR TITLE
Fix for Issue#1 - undefined method on non existent relation on object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.3
+
+Fixing Issue#1 - undefined method error on object which does not have relation established, and the can rule containes conditions on that relation.
+
 ## 1.0.2
 
 Fixing `cancancan` gem version to `<=2.1.4` as `cancancan-neo4j` gem is not compatible with higher version of  `cancancan`

--- a/lib/cancancan/model_adapters/neo4j_adapter.rb
+++ b/lib/cancancan/model_adapters/neo4j_adapter.rb
@@ -65,8 +65,9 @@ module CanCan
       def self.associations_conditions_match?(conditions, subject, base_class)
         return true if conditions.blank?
         conditions.all? do |association, conditions_hash|
-          current_model = base_class.associations[association].target_class
           current_subject = subject.send(association)
+          return false unless current_subject
+          current_model = base_class.associations[association].target_class
           all_conditions_match?(current_subject, conditions_hash, current_model)
         end
       end

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.0.2'.freeze
+    VERSION = '1.0.3'.freeze
   end
 end

--- a/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
@@ -116,6 +116,14 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
             include_context 'match expectations'
           end
 
+          context 'nested condition with 1st relation being has one' do
+            before(:example) do
+              @article2.user = @user
+              @ability.can :read, Article, user: {mentions: {active: true} }
+            end
+            include_context 'match expectations'
+          end
+
           context 'condition to check non existance of relation on one level deep model with base model conditions' do
             before(:example) do
               @article2.mentions << Mention.create!


### PR DESCRIPTION
If you have a can rule like `@ability.can :read, Article, user: {mentions: {active: true} }` and there is a `article` without a relation to `user`, then we were getting `undefined method on non existent mentions for nil class error`.

Fixed this by returning false if the `current_scope.relation` is `nil`.