### PR TITLE
issue#4 - variable length relations in conditions hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.0
+
+Fixing Issue#4 - ability to specify variable length relation in conditions hash of a rule.
+
 ## 1.0.3
 
 Fixing Issue#1 - undefined method error on object which does not have relation established, and the can rule containes conditions on that relation.

--- a/lib/cancancan/model_adapters/neo4j_adapter.rb
+++ b/lib/cancancan/model_adapters/neo4j_adapter.rb
@@ -65,7 +65,8 @@ module CanCan
       def self.associations_conditions_match?(conditions, subject, base_class)
         return true if conditions.blank?
         conditions.all? do |association, conditions_hash|
-          current_subject = subject.send(association)
+          rel_length = conditions_hash.delete(:rel_length)
+          current_subject = subject.send(association, rel_length: rel_length)
           return false unless current_subject
           current_model = base_class.associations[association].target_class
           all_conditions_match?(current_subject, conditions_hash, current_model)

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.0.3'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
@@ -119,7 +119,7 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
           context 'nested condition with 1st relation being has one' do
             before(:example) do
               @article2.user = @user
-              @ability.can :read, Article, user: {mentions: {active: true} }
+              @ability.can :read, Article, user: { mentions: { active: true } }
             end
             include_context 'match expectations'
           end
@@ -435,6 +435,19 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
         table_z = Namespace::TableZ.create(user: user)
         table_x.table_zs << table_z
         expect(Namespace::TableX.accessible_by(ability)).to eq([table_x])
+      end
+    end
+
+    context ' condition with variable length relation' do
+      it 'fetches all variable length realtion nodes with conditions' do
+        active_user = User.create!(name: 'Chunky-2', status: 'active')
+        inactive_user = User.create!(name: 'Chunky-1', friends: [active_user])
+        user = User.create!(name: 'Chunky', friends: [inactive_user])
+        ability = Ability.new(user)
+        ability.can :read, User, friends: { status: 'active',
+                                            rel_length: { min: 0 } }
+        expect(User.accessible_by(ability)).to contain_exactly(active_user)
+        expect(ability).to be_able_to(:read, active_user)
       end
     end
 

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -45,9 +45,11 @@ end
 class User
   include Neo4j::ActiveNode
   property :name, type: String
+  property :status, type: String
 
   has_many :in, :articles, origin: :user
   has_many :in, :mentions, origin: :user
+  has_many :out, :friends, type: :friend, model_class: self
 end
 
 module Namespace


### PR DESCRIPTION
Currently there is no way to specify variable length on relations in conditions hash of the can rule.
eg. we would like to have conditions specified in following manner,
`can :read, User, friends: { status: 'active', rel_length: { min: 0 } }`

Here friends is a self relation on user.
With this change we will be able provide way to define such rules as above.