### PR TITLE
Issue 4 variable lenght relation condition 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.1
+
+Fixing in case the variable length is specified on association and that association also has asssociation conditions, the variable lenght association condition was not working.
+
 ## 1.2.0
 
 Fixing Issue#4 - ability to specify variable length relation in conditions hash of a rule.

--- a/lib/cancancan/model_adapters/neo4j_adapter.rb
+++ b/lib/cancancan/model_adapters/neo4j_adapter.rb
@@ -78,6 +78,7 @@ module CanCan
       def records_for_multiple_rules
         base_query = base_query_proxy.query
         cypher_options = construct_cypher_options
+        cypher_options[:matches].reject! { |mt| mt.match(var_name(@model_class)) }
         match_string = cypher_options[:matches].uniq.join(', ')
         base_query = base_query.match(match_string) unless match_string.blank?
         base_query

--- a/lib/cancancan/neo4j/association_conditions.rb
+++ b/lib/cancancan/neo4j/association_conditions.rb
@@ -20,7 +20,7 @@ module CanCanCan
           rel_length = associations_conditions.delete(:rel_length)
           current_path = append_path_to_conditions(relationship, model_conditions, rel_length)
           append_model_conditions(model_conditions, relationship, current_path)
-          append_association_conditions(associations_conditions, relationship)
+          append_association_conditions(associations_conditions, relationship, rel_length)
         end
       end
 
@@ -28,9 +28,9 @@ module CanCanCan
         @options[:parent_class].associations[association]
       end
 
-      def append_association_conditions(conditions, relationship)
+      def append_association_conditions(conditions, relationship, rel_length)
         return if conditions.blank?
-        asso_conditions_obj = AssociationConditions.new(asso_conditions: conditions, parent_class: relationship.target_class, path: path_with_relationship(relationship))
+        asso_conditions_obj = AssociationConditions.new(asso_conditions: conditions, parent_class: relationship.target_class, path: path_with_relationship(relationship, rel_length))
         append_and_to_conditions_string
         @conditions_string += asso_conditions_obj.conditions_string
         @cypher_matches += asso_conditions_obj.cypher_matches
@@ -68,8 +68,9 @@ module CanCanCan
         @conditions_string += con_string
       end
 
-      def path_with_relationship(relationship)
-        @options[:path] + relationship.arrow_cypher + '()'
+      def path_with_relationship(relationship, rel_length)
+        arrow_cypher = relationship.arrow_cypher(nil, {}, false, false, rel_length)
+        @options[:path] + arrow_cypher + '()'
       end
     end
   end

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.2.0'.freeze
+    VERSION = '1.2.1'.freeze
   end
 end

--- a/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
@@ -449,6 +449,19 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
         expect(User.accessible_by(ability)).to contain_exactly(active_user)
         expect(ability).to be_able_to(:read, active_user)
       end
+
+      it 'fetches all variable length realtion nodes with nested relation conditions' do
+        active_user = User.create!(name: 'Chunky-2', status: 'active')
+        inactive_user = User.create!(name: 'Chunky-1', friends: [active_user])
+        user = User.create!(name: 'Chunky', friends: [inactive_user])
+        active_user.articles = [Article.create!(published: true)]
+        ability = Ability.new(user)
+        ability.can :read, User, friends: { status: 'active',
+                                            rel_length: { min: 0 },
+                                            articles: { published: true } }
+        expect(User.accessible_by(ability)).to contain_exactly(active_user)
+        expect(ability).to be_able_to(:read, active_user)
+      end
     end
 
     # TODO: Fix code to pass this


### PR DESCRIPTION
Fixing in case the variable length is specified on association and that association also has asssociation conditions, the variable lenght association condition was not working.