### PR TITLE
adding label to end node of cypher path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.2
+
+Adding label in relation path end node. eg. changing MATCH (article:Article) WHERE (( NOT (article:Article)-[:mention]->()-[:user]->()))' to MATCH (article:Article) WHERE (( NOT (article:Article)-[:mention]->(:Mention)-[:user]->(:User)))'
+
 ## 1.2.1
 
 Fixing in case the variable length is specified on association and that association also has asssociation conditions, the variable lenght association condition was not working.

--- a/lib/cancancan/neo4j/association_conditions.rb
+++ b/lib/cancancan/neo4j/association_conditions.rb
@@ -41,9 +41,8 @@ module CanCanCan
         model_attr_exists = model_conditions.any? do |key, _|
           !target_class.associations_keys.include?(key)
         end
-        end_node = model_attr_exists ? CypherConstructorHelper.match_node_cypher(target_class) : '()'
-        arrow_cypher = relationship.arrow_cypher(nil, {}, false, false, rel_length)
-        current_path = @options[:path] + arrow_cypher + end_node
+        to_node = CypherConstructorHelper.match_node_cypher(target_class) if model_attr_exists
+        current_path = path_with_relationship(relationship, rel_length, to_node)
         if model_attr_exists
           append_matches(relationship)
           append_and_to_conditions_string
@@ -68,9 +67,10 @@ module CanCanCan
         @conditions_string += con_string
       end
 
-      def path_with_relationship(relationship, rel_length)
+      def path_with_relationship(relationship, rel_length, to_node = nil)
         arrow_cypher = relationship.arrow_cypher(nil, {}, false, false, rel_length)
-        @options[:path] + arrow_cypher + '()'
+        to_node_label = CypherConstructorHelper.path_end_node(relationship)
+        @options[:path] + arrow_cypher + (to_node || to_node_label)
       end
     end
   end

--- a/lib/cancancan/neo4j/cypher_constructor_helper.rb
+++ b/lib/cancancan/neo4j/cypher_constructor_helper.rb
@@ -35,7 +35,8 @@ module CanCanCan
 
         def condtion_for_path(path:, variable_name:, base_class:, key:)
           path = "(#{variable_name})" if path.blank?
-          path + base_class.associations[key].arrow_cypher + '()'
+          relationship = base_class.associations[key]
+          path + relationship.arrow_cypher + path_end_node(relationship)
         end
 
         def condition_for_id(base_class, variable_name, value)
@@ -64,6 +65,10 @@ module CanCanCan
                       end
           connector += 'NOT' if rule_cypher.append_not_to_conditions?
           cypher_options[:conditions] = conditions_string + connector
+        end
+
+        def path_end_node(relationship)
+          '(' + relationship.target_class.mapped_label_names.map { |label_name| ":`#{label_name}`" }.join + ')'
         end
       end
     end

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.2.1'.freeze
+    VERSION = '1.2.2'.freeze
   end
 end

--- a/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
+++ b/spec/cancancan/model_adapters/neo4j_adapter_spec.rb
@@ -438,7 +438,7 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
       end
     end
 
-    context ' condition with variable length relation' do
+    context 'condition with variable length relation' do
       it 'fetches all variable length realtion nodes with conditions' do
         active_user = User.create!(name: 'Chunky-2', status: 'active')
         inactive_user = User.create!(name: 'Chunky-1', friends: [active_user])
@@ -461,6 +461,16 @@ if defined? CanCan::ModelAdapters::Neo4jAdapter
                                             articles: { published: true } }
         expect(User.accessible_by(ability)).to contain_exactly(active_user)
         expect(ability).to be_able_to(:read, active_user)
+      end
+    end
+
+    context 'condition on association' do
+      it 'constructs correct cypher with association node lable' do
+        @ability.can :read, Article, mentions: { user: nil }
+        expect(Article.accessible_by(@ability).to_cypher).to eq(
+          'MATCH (article:`Article`) WHERE (( NOT (article:`Article`)-'\
+          '[:`mention`]->(:`Mention`)-[:`user`]->(:`User`)))')
+
       end
     end
 


### PR DESCRIPTION
Adding label in relation path end node. eg. changing `MATCH (article:Article) WHERE (( NOT (article:Article)-[:mention]->()-[:user]->()))'` to `MATCH (article:Article) WHERE (( NOT (article:Article)-[:mention]->(:Mention)-[:user]->(:User)))'` This is more readable and preforms better as labels on nodes are present as recommended by `neo4j`