### PR TITLE
Fixing compatibility issue with cancancan-2.2.0

### DIFF
--- a/cancancan-neo4j.gemspec
+++ b/cancancan-neo4j.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel', '<5.2.0'
-  spec.add_dependency 'cancancan', '<=2.1.4'
+  spec.add_dependency 'cancancan'
   spec.add_dependency 'neo4j', '>= 9.0.0'
 
   spec.add_development_dependency 'bundler', '>= 1.3'

--- a/lib/cancancan/neo4j.rb
+++ b/lib/cancancan/neo4j.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'cancancan'
 require 'neo4j'
 


### PR DESCRIPTION
The latest version of cancancan-2.2.0 has breaking changes in adapter. Changes introduced by https://github.com/CanCanCommunity/cancancan/pull/495 in cancancan are giving error 'Uninitialised constant ActiveSupport'.
Fixing the issue with requiring active_support.