### PR TITLE
remove_rails_version_dependency

### DIFF
--- a/cancancan-neo4j.gemspec
+++ b/cancancan-neo4j.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files lib init.rb cancancan-neo4j.gemspec`.split($INPUT_RECORD_SEPARATOR)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activemodel', '<5.2.0'
   spec.add_dependency 'cancancan'
   spec.add_dependency 'neo4j', '>= 9.0.0'
 


### PR DESCRIPTION
Removed  active_model version dependency of `<5.2.0'` as it got fixed in neo4j gem 