### PR TITLE
Optimising execution in a case where multiple can rules with one can rule without conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.3.2
+
+Optimising cypher for single can rule.
+Optimising execution for multiple can rules with one rule with no conditions.
+
 ## 1.3.1
 
 Fixing Issue#12 - Authorizing single resource for a scope based rule

--- a/lib/cancancan/model_adapters/neo4j_adapter.rb
+++ b/lib/cancancan/model_adapters/neo4j_adapter.rb
@@ -60,7 +60,7 @@ module CanCan
 
       def logical_single_can_rule
         return @rules.first if @rules.size == 1
-        return unless @rules.all? { |rule| rule.base_behavior }
+        return unless @rules.all?(&:base_behavior)
         @rules.find { |rule| rule.conditions.blank? }
       end
 

--- a/lib/cancancan/neo4j/rule_cypher.rb
+++ b/lib/cancancan/neo4j/rule_cypher.rb
@@ -46,7 +46,7 @@ module CanCanCan
       end
 
       def condition_for_rule_without_conditions
-        @rule_conditions = @options[:rule].base_behavior ? '(true)' : '(false)'
+        @rule_conditions = @options[:rule].base_behavior ? '' : '(false)'
       end
 
       def construct_cypher_options

--- a/lib/cancancan/neo4j/version.rb
+++ b/lib/cancancan/neo4j/version.rb
@@ -2,6 +2,6 @@ module CanCanCan
 end
 module CanCanCan
   module Neo4j
-    VERSION = '1.3.1'.freeze
+    VERSION = '1.3.2'.freeze
   end
 end


### PR DESCRIPTION
Optimising cypher with eliminating `WITH` and `UNWIND` clauses from cypher in case when multiple can rules exists and one of them is without any conditions, a plain `can :read, User` rule.